### PR TITLE
removed minimum size difference for nextjs-bundle-analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   "nextBundleAnalysis": {
     "budget": 512000,
     "budgetPercentIncreaseRed": 85,
-    "minimumChangeThreshold": 100000,
     "showDetails": true
   }
 }


### PR DESCRIPTION
minimumChangeThreshhold in package.json was set too high. 
Completely removed the option so it should always display size differences